### PR TITLE
(CDPE-739) Update module dependencies

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,11 +8,11 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.19.0 < 5.0.0"
+      "version_requirement": ">= 4.19.0 < 6.0.0"
     },
     {
       "name": "puppetlabs-puppet_authorization",
-      "version_requirement": ">= 0.4.0 < 1.0.0"
+      "version_requirement": ">= 0.5.0 < 1.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
This commit updated the dependencies of the cd4pe module to require 0.5.0
or newer of puppetlabs-puppet_authorization and to allow puppetlabs-stdlib
5.x. Due to transitive dependencies, update to puppet_authorization also allows
the c4pe module to be installed into environments where puppetlabs-concat 5.x
is in use.