### PR TITLE
(maint) Update dependency module name

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,7 @@
       "version_requirement": ">= 0.5.0 < 1.0.0"
     },
     {
-      "name": "puppetlbs-pipelines",
+      "name": "puppetlabs-pipelines",
       "version_requirement": ">= 1.0.0 < 2.0.0"
     }
 


### PR DESCRIPTION
Prior to this commit, there was a typo in the name of the
puppetlabs-pipelines module name. This commit fixes that name in the
metadata.json.