### PR TITLE
(CDPE-1065) Switch impact_analysis PE version check to server side function call

### DIFF
--- a/manifests/impact_analysis.pp
+++ b/manifests/impact_analysis.pp
@@ -33,7 +33,7 @@ class cd4pe::impact_analysis (
      'absent'  => absent,
    }
 
-  if (versioncmp(fact('pe_server_version'), '2019.0.2') >= 0) {
+  if (versioncmp(pe_build_version(), '2019.0.2') >= 0) {
     $jar_source_name = 'cdpe-api-aot.jar'
   } else {
     $jar_source_name = 'cdpe-api.jar'


### PR DESCRIPTION
Prior to this update, compile masters could not be added after
impact analysis was enabled on the primary master.  This was caused
by the reliance on the pe_server_version fact, which is not
present on an agent when it is first being classified as a compile
master.

This commit switches the fact lookup with a call to pe_build_version()
from the puppet_enterprise module.  Since compile masters must run
the same PE version as the primary master, checking it locally on
the primary master via a function should accomplish the same goal.