### PR TITLE
Adding task to allow updating license

### DIFF
--- a/lib/puppet_x/puppetlabs/cd4pe_client.rb
+++ b/lib/puppet_x/puppetlabs/cd4pe_client.rb
@@ -81,6 +81,14 @@ module PuppetX
         make_request(:post, '/root-account', payload.to_json)
       end
 
+      def save_license(license)
+        payload = {
+          op: 'RootSavePfiLicense',
+          content: license
+        }
+        make_request(:post, ROOT_AJAX_ENDPOINT, payload.to_json)
+      end
+
       def save_endpoint_settings(webui, backend, agent)
         payload = {
           op: 'SaveEndpointSettings',

--- a/tasks/update_license.json
+++ b/tasks/update_license.json
@@ -1,0 +1,26 @@
+{
+  "description": "Updates the license file for CD4PE.",
+  "parameters": {
+    "resolvable_hostname": {
+      "type": "Optional[String[1]]",
+      "description": "A resolvable internet address where the Continuous Delivery for PE server can be reached. Required only if the agent certificate is not the machine's resolvable internet address."
+    },
+    "web_ui_endpoint": {
+      "type": "Optional[String[1]]",
+      "description": "The endpoint where the web UI can be reached, in the form http://<resolvable_hostname>:<port>. Required if you set the web_ui_port parameter in the cd4pe class during installation."
+    },
+    "root_email": {
+      "type": "String",
+      "description": "The email address associated with the CDPE root account."
+    },
+    "root_password": {
+      "type": "String",
+      "description": "The password associated with the CDPE root account."
+    },
+    "license": {
+      "type": "Hash",
+      "description": "The JSON content of the license downloaded from https://licenses.puppet.com/"
+    }
+  },
+  "input_method": "stdin"
+}

--- a/tasks/update_license.rb
+++ b/tasks/update_license.rb
@@ -1,0 +1,38 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+
+require 'puppet'
+require 'uri'
+
+Puppet.initialize_settings
+$:.unshift(Puppet[:plugindest])
+
+require 'puppet_x/puppetlabs/cd4pe_client'
+
+params = JSON.parse(STDIN.read)
+hostname                 = params['resolvable_hostname'] || Puppet[:certname]
+username                 = params['root_email']
+password                 = params['root_password']
+license                  = params['license']
+
+
+uri = URI.parse(hostname)
+hostname = "http://#{hostname}" if uri.scheme == nil
+
+
+web_ui_endpoint          = params['web_ui_endpoint'] || "#{hostname}:8080"
+
+begin
+  client = PuppetX::Puppetlabs::CD4PEClient.new(web_ui_endpoint, username, password)
+  res = client.save_license(license)
+  if res.code != '200'
+    raise Puppet::Error "Error while saving license: #{res.body}"
+  end
+
+  puts "License updated"
+
+
+  exit 0
+rescue Puppet::Error => e
+  puts({ status: 'failure', error: e.message }.to_json)
+  exit 1
+end


### PR DESCRIPTION
This commit adds a task that allows a user to update their license
file.  This allows for the potential automation of license updates
when about to expire.