### PR TITLE
(CDPE-1566) Fix deps between cd4pe and root_config

### DIFF
--- a/manifests/anchors.pp
+++ b/manifests/anchors.pp
@@ -1,0 +1,18 @@
+# @summary
+#   Defines dependency ordering anchors used by other CD4PE classes. These
+#   anchors allow relative ordering to be established between classes which
+#   may or may not all be present in a configuration. The ordering is defined
+#   against the anchors, which WILL always be present when any of the classes
+#   that use them are applied.
+#
+class cd4pe::anchors {
+
+  # Anchor to indicate that service installation is finished. Intended to be
+  # used with before/require.
+  anchor { 'cd4pe-service-install': }
+
+  # Anchor to pass through refresh events to the service definition. Intended
+  # to be used with notify/subscribe.
+  anchor { 'cd4pe-service-refresh': }
+
+}

--- a/manifests/root_config.pp
+++ b/manifests/root_config.pp
@@ -19,6 +19,14 @@ class cd4pe::root_config(
   Optional[String[1]] $ssl_endpoint                        = undef,
   Optional[Integer] $ssl_port                              = 8443,
 ) inherits cd4pe {
+  include cd4pe::anchors
+
+  # If SSL is enabled, trigger a refresh of the CD4PE service on config update.
+  # If SSL is not enabled, there's no need.
+  $notify = $ssl_enabled ? {
+    true    => Anchor['cd4pe-service-refresh'],
+    default => undef,
+  }
 
   cd4pe_root_config { $web_ui_endpoint:
     root_email                => $root_email,
@@ -39,6 +47,8 @@ class cd4pe::root_config(
     ssl_server_private_key    => $ssl_server_private_key,
     ssl_endpoint              => $ssl_endpoint,
     ssl_port                  => $ssl_port,
-    notify                    => Docker::Run['cd4pe'],
+    require                   => Anchor['cd4pe-service-install'],
+    notify                    => $notify,
   }
+
 }


### PR DESCRIPTION
Previously, when cd4pe and cd4pe::root_config were applied
simultaneously, a deadlock could occur wherein CD4PE could not be
installed because it could not be configured, because it was not
running.

This commit creates a more intelligent dependency ordering allowing
CD4PE to be first installed, then configured, then refreshed if
necessary.