### PR TITLE
Improve password security

### DIFF
--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -66,7 +66,8 @@ class cd4pe::db(
       ensure  => file,
       owner   => 'root',
       group   => 'root',
-      content => "DB_PASS=${_db_pass}\n",
+      mode    => '0400',
+      content => Sensitive.new("DB_PASS=${_db_pass}\n"),
       replace => false,
     }
 

--- a/manifests/db/mysql.pp
+++ b/manifests/db/mysql.pp
@@ -21,7 +21,8 @@ class cd4pe::db::mysql(
     ensure  => file,
     owner   => 'root',
     group   => 'root',
-    content => "DB_PASS=${_db_pass}\n",
+    mode    => '0400',
+    content => Sensitive.new("DB_PASS=${_db_pass}\n"),
     replace => false,
   }
 
@@ -43,7 +44,8 @@ class cd4pe::db::mysql(
     ensure  => file,
     owner   => 'root',
     group   => 'root',
-    content => "MYSQL_ROOT_PASSWORD=${$_db_pass}\nMYSQL_PASSWORD=${$_db_pass}\n",
+    mode    => '0400',
+    content => Sensitive.new("MYSQL_ROOT_PASSWORD=${$_db_pass}\nMYSQL_PASSWORD=${$_db_pass}\n"),
     replace => false,
   }
 


### PR DESCRIPTION
This ensures that the files on disk are written to be read-only and only
accessable by root. It also uses the Sensitive data type to ensure that
file contents is redacted from logs and PuppetDB

Note that this *has not been tested on a running system* because I couldn't work out how to run the beaker tests and it doesn't seem to be documented. Can someone please run these for me?