### PR TITLE
ensure default local docker hostname resolution

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -110,7 +110,10 @@ class cd4pe (
   $master_ip     = getvar('serverip')
 
   if $master_ip and $manage_pe_host_mapping {
-    $extra_params = ["--add-host ${master_server}:${master_ip}"] + $cd4pe_docker_extra_params
+    $extra_params = [
+      "--add-host ${master_server}:${master_ip}",
+      "--add-host ${trusted['certname']}:${facts['ipaddress']}"
+      ] + $cd4pe_docker_extra_params
   } else {
     $extra_params = $cd4pe_docker_extra_params
   }


### PR DESCRIPTION
This changes ensure that the created cd4pe container is able to resolve the parent docker host by its Puppet certname