### PR TITLE
(CDPE-2723) Updates metadata OS requirements

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -33,21 +33,7 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "6",
         "7"
-      ]
-    },
-    {
-      "operatingsystem": "Ubuntu",
-      "operatingsystemrelease": [
-        "16.04",
-        "18.04"
-      ]
-    },
-    {
-      "operatingsystem": "SLES",
-      "operatingsystemrelease": [
-        "12"
       ]
     }
   ],


### PR DESCRIPTION
This module isn't supported for anything except RHEL 7, updating the metadata to reflect that.