### PR TITLE
(CDPE-2723) Adds conditional for Ubuntu db config directory

### DIFF
--- a/manifests/db/postgres.pp
+++ b/manifests/db/postgres.pp
@@ -89,10 +89,14 @@ class cd4pe::db::postgres(
     require => Class['pe_postgresql::server::install'],
     before  => Class['pe_postgresql::server::initdb'],
   }
+
   # Ensure /etc/sysconfig/pgsql exists so the module can create and manage
-  # pgsql/postgresql
-  -> file { '/etc/sysconfig/pgsql':
-    ensure => directory,
+  # pgsql/postgresql on el-7
+  if ($facts['os']['family'] == 'RedHat') and ($facts['os']['release']['major'] !~ '^7') {
+    file { '/etc/sysconfig/pgsql':
+      ensure  => directory,
+      require => File[$pgsqldir, "${pgsqldir}/${pg_version}" ],
+    }
   }
 
   # get the pg server up and running


### PR DESCRIPTION
This fixes Puppet runs for Ubuntu machines, as `/etc/sysconfig/` is an EL-specific filepath.

This is the same as https://github.com/puppetlabs/puppetlabs-cd4pe/pull/57, which I can't re-open because I deleted the fork.