### PR TITLE
Ensure File resource doesn't show up in IAs

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,7 +39,7 @@ class cd4pe (
     ensure  => file,
     owner   => 'root',
     group   => 'root',
-    content => "PFI_SECRET_KEY=${secret_key}\n",
+    content => Sensitive("PFI_SECRET_KEY=${secret_key}\n"),
     replace => false,
   }
 


### PR DESCRIPTION
Changing the `content` of the `file { $secret_key_path: }` resource to the Sensitive data type will automatically cause CD4PE Impact Analysis to ignore it. This ensures that this resource doesn't show up in every Impact Analysis with a `Diff is too large` message.