### PR TITLE
WIP: Added more mountpoint functionality

### DIFF
--- a/manifests/db/postgres/certs.pp
+++ b/manifests/db/postgres/certs.pp
@@ -7,16 +7,20 @@ class cd4pe::db::postgres::certs(
   String $client_private_key,
 ){
 
-  $certname           = $trusted['certname']
-  $cert_dir           = "${cd4pe::db::data_root_dir}/certs"
-  $target_ca_cert     = "${cert_dir}/ca.pem"
-  $target_client_cert = "${cert_dir}/client_cert.pem"
-  $pk8_file           = "${cert_dir}/client_private_key.pk8"
-  $ssl_db_env         = "${cd4pe::db::data_root_dir}/ssl_db_env"
+  $certname            = $trusted['certname']
+  $cert_dir            = "${cd4pe::db::data_root_dir}/certs"
+  $target_ca_cert      = "${cert_dir}/ca.pem"
+  $target_client_cert  = "${cert_dir}/client_cert.pem"
+  $pk8_file            = "${cert_dir}/client_private_key.pk8"
+  $ssl_db_env          = "${cd4pe::db::data_root_dir}/ssl_db_env"
+  $volume_mount_suffix = $facts['os'].dig('selinux', 'enabled') ? {
+    true    => ':Z',
+    default => '',
+  }
 
   # Copy the local agent certs for the container to use, and mount them
   Docker::Run <| title == 'cd4pe' |> {
-    volumes    +> ["${cert_dir}:/certs"],
+    volumes    +> ["${cert_dir}:/certs${volume_mount_suffix}"],
     env_file   +> [$ssl_db_env],
   }
 


### PR DESCRIPTION
* Users can now supply a path on disk that will be used for the
`/disk` mountpoint, allowing for more sane backups etc.
* SELinux contexts are automatically applied to all volumes.
Previously CD4PE would not start if SELinux was enforcing.

Previously you would get errors from chown or `process_linux.go` such as:

```
Error: unable to start container 8cdbdcfbe17f3b56551a8ffeb837591e5a19be4d59adebfa65c6da625746c28e: container_linux.go:345: starting container process caused "process_linux.go:430: container init caused \"write /proc/self/attr/keycreate: permission denied\""
: OCI runtime error
```