### PR TITLE
Update puppet apply check logic

### DIFF
--- a/manifests/db/postgres.pp
+++ b/manifests/db/postgres.pp
@@ -11,7 +11,7 @@ class cd4pe::db::postgres(
 ) {
 
 
-  if(pe_compiling_server_version()) {
+  if( fact('cd4pe_multimodule_packaging') =~ Undef ) { {
     # This is being compiled via classification, so we can include
     # the packages class and auto-determine the versioning
     include cd4pe::repo


### PR DESCRIPTION
Prior to this commit, if you run the cd4pe install task from the PE console more than once the second run will fail because it tries to include cdpe::repo which doesn't work via puppet apply. 

After this commit, we update the logic to hinge on whether we are passing the cd4pe_multimodule_package fact like the task does.