### PR TITLE
make sure containers can communicate with postgresql

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -126,6 +126,10 @@ class cd4pe (
       "--add-host ${master_server}:${master_ip}",
       "--add-host ${trusted['certname']}:${facts['ipaddress']}"
       ] + $cd4pe_docker_extra_params
+  } elsif $manage_pe_host_mapping {
+    $extra_params = [
+      "--add-host ${trusted['certname']}:${facts['ipaddress']}"
+      ] + $cd4pe_docker_extra_params
   } else {
     $extra_params = $cd4pe_docker_extra_params
   }


### PR DESCRIPTION
Prior to this commit, we only do an --add-host for the cd4pe host into docker if we can also do that for the master host.  If for some reason we can get the ip of the master host then the cd4pe host won't be added in.  

After this commit, we add in the cd4pe host if we have manage_pe_host_mapping set to true.