### PR TITLE
(CDPE-3005) Fail if running the module on EL 8

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,6 +21,10 @@ class cd4pe (
   Optional[String[1]] $cd4pe_network_subnet                   = undef,
   Optional[String[1]] $cd4pe_network_gateway                  = undef,
 ){
+
+  if ( $facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] == '8' ){
+    fail('You cannot use the cd4pe module to install on EL 8')
+  }
   # Restrict to linux only?
   include docker
   include cd4pe::anchors


### PR DESCRIPTION
Prior to this commit, running the module on EL 8 would fail
for various reasons the most notable the inability to install
docker on el 8.

After this commit, we just fail on el 8.