### PR TITLE
(CDPE-3131) Align pdb timeout env variable with backend code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ inventory.yaml
 /update_report.txt
 .DS_Store
 target/*
+test/params.json
+params.json

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,7 +1,7 @@
 class cd4pe (
   Integer $agent_service_port                                 = 7000,
   Boolean $analytics                                          = true,
-  Optional[String[1]] $puppet_db_connection_timeout_sec       = undef,
+  Optional[Integer[1]] $puppetdb_connection_timeout_sec       = undef,
   Integer $backend_service_port                               = 8000,
   Array[String] $cd4pe_docker_extra_params                    = [],
   String $cd4pe_image                                         = 'puppet/continuous-delivery-for-puppet-enterprise',
@@ -99,7 +99,7 @@ class cd4pe (
 
   $app_data = {
     analytics                        => $analytics,
-    puppet_db_connection_timeout_sec => $puppet_db_connection_timeout_sec,
+    puppetdb_connection_timeout_sec => $puppetdb_connection_timeout_sec,
   }
 
   $app_env_path = "${data_root_dir}/env"

--- a/templates/app_env.epp
+++ b/templates/app_env.epp
@@ -1,8 +1,8 @@
 <%- |
       Boolean $analytics,
-      Optional[String[1]] $puppet_db_connection_timeout_sec,
+      Optional[Integer[1]] $puppetdb_connection_timeout_sec,
 | -%>
 ANALYTICS=<%= $analytics %>
-<% if($puppet_db_connection_timeout_sec) { -%>
-PUPPET_DB_CONNECTION_TIMEOUT_SEC=<%= $puppet_db_connection_timeout_sec %>
+<% if($puppetdb_connection_timeout_sec) { -%>
+PUPPETDB_CONNECTION_TIMEOUT_SEC=<%= $puppetdb_connection_timeout_sec %>
 <% } -%>


### PR DESCRIPTION
Prior to this commit, changing the PDB timeout caused the module to add
PUPPET_DB_CONNECTION_TIMEOUT_SEC to the env file for cd4pe.
Unfortunately, this is not the name of the variable the backend code is
looking for, so the setting is never honored.

With this commit, the variable is renamed to
PUPPETDB_CONNECTION_TIMEOUT_SEC to match what the code is looking for at
https://github.com/puppetlabs/PipelinesInfra/blob/3.5.0-release/src/main/java/com/puppet/enterprise/puppetdb/PuppetDBClient.java#L46.  I also updated the internal variable names to match this naming scheme.

I also switch the data type from String to Integer, since it should always be a number.

Testing:
```
[(root@pe-201922-master) ~>]
# echo "cd4pe::puppetdb_connection_timeout_sec: 600" >> /etc/puppetlabs/code/environments/production/data/common.yaml
[(root@pe-201922-master) ~>]
# curl --cert $(puppet config print hostcert) --key $(puppet config print hostprivkey)  --cacert $(puppet config print localcacert) -X DELETE https://$(hostname -f):8140/puppet-admin-api/v1/environment-cache
```

```
[(root@pe-201922-agent-cdpe) /etc/puppetlabs/cd4pe>]
# puppet agent -t
Info: Using configured environment 'production'
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Retrieving locales
Info: Loading facts
Info: Caching catalog for pe-201922-agent-cdpe.puppetdebug.vlan
Info: Applying configuration version 'pe-201922-master-production-e6996225ddb'
Notice: /Stage[main]/Cd4pe/File[/etc/puppetlabs/cd4pe/env]/content: content changed '{md5}477a6b7cb722b7643034db089a5b1ab7' to '{md5}092ca124bcd823c27d5747b7865f6af5'
Info: /Stage[main]/Cd4pe/File[/etc/puppetlabs/cd4pe/env]: Scheduling refresh of Docker::Run[cd4pe]
Info: Docker::Run[cd4pe]: Scheduling refresh of Service[docker-cd4pe]
Info: Docker::Run[cd4pe]: Scheduling refresh of Exec[docker-cd4pe-systemd-reload]
Notice: /Stage[main]/Cd4pe/Docker::Run[cd4pe]/Exec[docker-cd4pe-systemd-reload]: Triggered 'refresh' from 1 event
Notice: /Stage[main]/Cd4pe/Docker::Run[cd4pe]/Service[docker-cd4pe]: Triggered 'refresh' from 1 event
Notice: Applied catalog in 2.64 seconds
[(root@pe-201922-agent-cdpe) /etc/puppetlabs/cd4pe>]
# cat /etc/puppetlabs/cd4pe/env
ANALYTICS=true
PUPPETDB_CONNECTION_TIMEOUT_SEC=600
[(root@pe-201922-agent-cdpe) /etc/puppetlabs/cd4pe>]
# docker exec -it cd4pe env |grep PUPPETDB
PUPPETDB_CONNECTION_TIMEOUT_SEC=600
```