### PR TITLE
(maint) Run configTestVm.sh from a container

### DIFF
--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,0 +1,22 @@
+FROM ruby:2.4.1
+RUN apt-get update && \
+    apt-get install -y jq && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN { \
+    echo "#!/bin/bash"; \
+    echo "eval \$(ssh-agent) >/dev/null"; \
+    echo "ssh-add /root/.ssh/id_rsa"; \
+    echo "exec \"\$@\""; \
+    } > /entrypoint.sh && chmod 755 /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
+RUN mkdir -p /root/.puppetlabs/bolt && \
+    echo "disabled: true" > /root/.puppetlabs/bolt/analytics.yaml
+
+COPY .cdpe-workflow-tests-config.json /root/
+
+WORKDIR /app
+COPY Gemfile ./
+RUN bundle install
+WORKDIR /app/test

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -3,10 +3,11 @@ RUN apt-get update && \
     apt-get install -y jq && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
+ENV SSH_KEY id_rsa
 RUN { \
     echo "#!/bin/bash"; \
     echo "eval \$(ssh-agent) >/dev/null"; \
-    echo "ssh-add /root/.ssh/id_rsa"; \
+    echo "ssh-add /root/.ssh/\$SSH_KEY"; \
     echo "exec \"\$@\""; \
     } > /entrypoint.sh && chmod 755 /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,17 @@
+REGISTRY ?= artifactory.delivery.puppetlabs.net
+TEST_IMAGE := $(REGISTRY)/cd4pe-config-test-vm:latest
+
+.PHONY: build-test-image push-test-image
+
+build-test-image:
+	cp $(HOME)/.cdpe-workflow-tests-config.json ..
+	docker build \
+		--pull \
+		--file Dockerfile \
+		--tag $(TEST_IMAGE) \
+		..
+	rm ../.cdpe-workflow-tests-config.json
+
+push-test-image:
+	docker login https://$(REGISTRY)
+	docker push $(TEST_IMAGE)

--- a/test/README.md
+++ b/test/README.md
@@ -2,7 +2,7 @@
 
 This tooling configures object storage, can enable SSL, creates a default user and workspace, and can set up a VCS for a freshly provisioned CD4PE VMs. It also creates the root account and sets a trial license.
 
-Use of this script requires a local copy of the `.cdpe-workflow-tests-config.json` file, which you can get from 1Password, and save it in your ${HOME} directory.
+Use of the `configTestVm.sh` script requires nothing but Docker. Your `~/.ssh/id_rsa` SSH key will be used to clone dependencies from private GitHub repositories.
 
 **Environmental setup**
 

--- a/test/README.md
+++ b/test/README.md
@@ -2,7 +2,7 @@
 
 This tooling configures object storage, can enable SSL, creates a default user and workspace, and can set up a VCS for a freshly provisioned CD4PE VMs. It also creates the root account and sets a trial license.
 
-Use of the `configTestVm.sh` script requires nothing but Docker. Your `~/.ssh/id_rsa` SSH key will be used to clone dependencies from private GitHub repositories.
+Use of the `configTestVm.sh` script requires nothing but Docker. By default your `~/.ssh/id_rsa` SSH key will be used to clone dependencies from private GitHub repositories, but a different key can be specified.
 
 **Environmental setup**
 
@@ -13,6 +13,8 @@ This was developed and tested using Ruby 2.4.1 (because thats what we use in Jen
     ./configTestVm.sh
 
 To specify the repo and version of the image to install, set the same environment vars as the build system, `CD4PE_IMAGE` and `CD4PE_VERSION`; the image repo defaults to `artifactory.delivery.puppetlabs.net/cd4pe-dev` and the currently supported database is `postgres`.
+
+To use a different SSH key other than `id_rsa`, set the `SSH_KEY` environment variable to the appropriate file under your ~/.ssh directory. For example, `SSH_KEY=id_dsa ./configTestVm.sh`.
 
 No arguments are required. By default, it will create a VM using the Artifactory object-store, not enable SSL and create a default user & workspace. To modify this behaviour, use the following switches (default values):
 

--- a/test/configTestVm.sh
+++ b/test/configTestVm.sh
@@ -1,116 +1,13 @@
 #!/usr/bin/env bash
-set -e
 
-function usage() {
-  echo
-  echo "No arguments are required. By default, create a VM using the Artifactory object-store,"
-  echo "not enable SSL, create a default user & workspace, and no VCS. To modify this behaviour,"
-  echo "use the following switches (default values):"
-  echo
-  echo "  -o|--object-store disk|artifactory      specify the object-store (${objectStorageType})"
-  echo "  -s|--ssl                                configure SSL (${sslEnabled})"
-  echo "  -b|--base <base>                        specify base name of workspace, email & username (${baseName})"
-  echo "  -v|--vcs-provider <vcs>                 specify the VCS provider (${vcsProvider})"
-}
+test_image=artifactory.delivery.puppetlabs.net/cd4pe-config-test-vm:latest
 
-function waitUntilCd4peUp() {
-  attempt_counter=0
-  max_attempts=60
-  echo "Waiting up to 5 minutes for CD4PE to come up"
+docker pull $test_image
 
-  until $(curl --output /dev/null --silent --head --fail http://${1}:8080); do
-    if [ ${attempt_counter} -eq ${max_attempts} ];then
-      echo
-      echo "Max attempts reached"
-      exit 1
-    fi
-
-    echo -n '.'
-    attempt_counter=$(($attempt_counter+1))
-    sleep 5
-  done
-  echo
-}
-
-# derived from https://medium.com/@frontman/how-to-parse-yaml-string-via-command-line-374567512303
-function yaml2json() {
-  ruby -ryaml -rjson -e 'puts JSON.pretty_generate(YAML.load(ARGF))' $*
-}
-
-# main
-#
-
-CD4PE_IMAGE=${CD4PE_IMAGE:-artifactory.delivery.puppetlabs.net/cd4pe-dev}
-[ -z "${CD4PE_VERSION}" ] && { echo "Please export CD4PE_VERSION to the desired version on Artifactory"; exit 1; }
-
-[ ! -r ${HOME}/.cdpe-workflow-tests-config.json ] && { echo "Please put ~/.cdpe-workflow-tests-config.json in place from 1Password" >&2; exit 1; }
-
-objectStorageType="artifactory"
-sslEnabled="disabled"
-baseName="otto"
-vcsProvider="none"
-
-## most parameters are qualified by the genParams.rb script, not in here
-## derived from https://medium.com/@Drew_Stokes/bash-argument-parsing-54f3b81a6a8f
-##
-PARAMS=""
-while (( "$#" )); do
-  case "$1" in
-    -o|--object-store)
-      objectStorageType="$2"
-      shift 2
-      ;;
-    -s|--ssl)
-      sslEnabled="enabled"
-      shift
-      ;;
-    -p|--no-op-check)
-      skipPoCheck="true"
-      shift
-      ;;
-    -b|--base)
-      baseName="$2"
-      shift 2
-      ;;
-    -v|--vcs-provider)
-      vcsProvider="$2"
-      shift 2
-      ;;
-    -h|--help)
-      usage
-      exit 1
-      ;;
-    --) # end argument parsing
-      shift
-      break
-      ;;
-    -*|--*=) # unsupported flags
-      echo "Error: Unsupported flag $1" >&2
-      usage
-      exit 1
-      ;;
-    *) # preserve positional arguments
-      PARAMS="$PARAMS $1"
-      shift
-      ;;
-  esac
-done
-# set positional arguments
-eval set -- "$PARAMS"
-
-moduledir='..'
-
-rm -f ../inventory.yaml
-bundle exec rake "test:install:cd4pe:module[${CD4PE_IMAGE},${CD4PE_VERSION}]"
-
-target=$(yaml2json ../inventory.yaml | jq -r '.groups[1].targets[0].uri')
-waitUntilCd4peUp ${target}
-
-./genParams.rb ${objectStorageType} ${sslEnabled} ${target} ${baseName} ${vcsProvider}
-
-bolt plan run --targets all --modulepath ${moduledir}/spec/fixtures/modules:${moduledir} --inventoryfile ../inventory.yaml cd4pe_test_tasks::configure_test_vm --params @params.json
-
-rm -f params.json
-
-echo
-echo "Your VM is available at http://${target}:8080 with a login of ${baseName:-otto}@example.com and the usual password :)"
+docker run -ti --rm \
+       --volume "$PWD"/..:/app \
+       --volume "$HOME"/.ssh:/root/.ssh \
+       --env CD4PE_IMAGE="$CD4PE_IMAGE" \
+       --env CD4PE_VERSION="$CD4PE_VERSION" \
+       $test_image \
+       /app/test/doConfigTestVm.sh "$@"

--- a/test/configTestVm.sh
+++ b/test/configTestVm.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+ssh_key=${SSH_KEY:-id_rsa}
+
 test_image=artifactory.delivery.puppetlabs.net/cd4pe-config-test-vm:latest
 
 docker pull $test_image
@@ -7,6 +9,7 @@ docker pull $test_image
 docker run -ti --rm \
        --volume "$PWD"/..:/app \
        --volume "$HOME"/.ssh:/root/.ssh \
+       --env SSH_KEY="$ssh_key" \
        --env CD4PE_IMAGE="$CD4PE_IMAGE" \
        --env CD4PE_VERSION="$CD4PE_VERSION" \
        $test_image \

--- a/test/doConfigTestVm.sh
+++ b/test/doConfigTestVm.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -e
+
+function usage() {
+  echo
+  echo "No arguments are required. By default, create a VM using the Artifactory object-store,"
+  echo "not enable SSL, create a default user & workspace, and no VCS. To modify this behaviour,"
+  echo "use the following switches (default values):"
+  echo
+  echo "  -o|--object-store disk|artifactory      specify the object-store (${objectStorageType})"
+  echo "  -s|--ssl                                configure SSL (${sslEnabled})"
+  echo "  -b|--base <base>                        specify base name of workspace, email & username (${baseName})"
+  echo "  -v|--vcs-provider <vcs>                 specify the VCS provider (${vcsProvider})"
+}
+
+function waitUntilCd4peUp() {
+  attempt_counter=0
+  max_attempts=60
+  echo "Waiting up to 5 minutes for CD4PE to come up"
+
+  until $(curl --output /dev/null --silent --head --fail http://${1}:8080); do
+    if [ ${attempt_counter} -eq ${max_attempts} ];then
+      echo
+      echo "Max attempts reached"
+      exit 1
+    fi
+
+    echo -n '.'
+    attempt_counter=$(($attempt_counter+1))
+    sleep 5
+  done
+  echo
+}
+
+# derived from https://medium.com/@frontman/how-to-parse-yaml-string-via-command-line-374567512303
+function yaml2json() {
+  ruby -ryaml -rjson -e 'puts JSON.pretty_generate(YAML.load(ARGF))' $*
+}
+
+# main
+#
+
+CD4PE_IMAGE=${CD4PE_IMAGE:-artifactory.delivery.puppetlabs.net/cd4pe-dev}
+[ -z "${CD4PE_VERSION}" ] && { echo "Please export CD4PE_VERSION to the desired version on Artifactory"; exit 1; }
+
+[ ! -r ${HOME}/.cdpe-workflow-tests-config.json ] && { echo "Please put ~/.cdpe-workflow-tests-config.json in place from 1Password" >&2; exit 1; }
+
+objectStorageType="artifactory"
+sslEnabled="disabled"
+baseName="otto"
+vcsProvider="none"
+
+## most parameters are qualified by the genParams.rb script, not in here
+## derived from https://medium.com/@Drew_Stokes/bash-argument-parsing-54f3b81a6a8f
+##
+PARAMS=""
+while (( "$#" )); do
+  case "$1" in
+    -o|--object-store)
+      objectStorageType="$2"
+      shift 2
+      ;;
+    -s|--ssl)
+      sslEnabled="enabled"
+      shift
+      ;;
+    -b|--base)
+      baseName="$2"
+      shift 2
+      ;;
+    -v|--vcs-provider)
+      vcsProvider="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 1
+      ;;
+    --) # end argument parsing
+      shift
+      break
+      ;;
+    -*|--*=) # unsupported flags
+      echo "Error: Unsupported flag $1" >&2
+      usage
+      exit 1
+      ;;
+    *) # preserve positional arguments
+      PARAMS="$PARAMS $1"
+      shift
+      ;;
+  esac
+done
+# set positional arguments
+eval set -- "$PARAMS"
+
+moduledir='..'
+
+rm -f ../inventory.yaml
+bundle exec rake "test:install:cd4pe:module[${CD4PE_IMAGE},${CD4PE_VERSION}]"
+
+target=$(yaml2json ../inventory.yaml | jq -r '.groups[1].targets[0].uri')
+waitUntilCd4peUp ${target}
+
+./genParams.rb ${objectStorageType} ${sslEnabled} ${target} ${baseName} ${vcsProvider}
+
+bolt plan run --targets all --modulepath ${moduledir}/spec/fixtures/modules:${moduledir} --inventoryfile ../inventory.yaml cd4pe_test_tasks::configure_test_vm --params @params.json
+
+rm -f params.json
+
+echo
+echo "Your VM is available at http://${target}:8080 with a login of ${baseName:-otto}@example.com and the usual password :)"


### PR DESCRIPTION
Create a new container that has all the dependencies -- including the
cdpe-workflow-tests-config.json file -- for running the manual test
automation scripts.

Only the dependencies are built into the container; the scripts
themselves and everything else will be mounted into the container from
the local repository directory.

In order to pull down the private Github repositories specified as
dependencies at runtime your ~/.ssh/id_rsa key will be used.

Since the Ruby Bundler gems have been built into the image, whenever
the Gemfile changes a new image should be built and pushed. A Makefile
with build and push targets has been provided for this.

If desired during development, Docker can be omitted and the
doConfigTestVm.sh script can be executed directly so long as the
dependencies have been installed.