### PR TITLE
(maint) Fix potential SSH issues and add Gemfile.lock note

### DIFF
--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -3,11 +3,13 @@ RUN apt-get update && \
     apt-get install -y jq && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-ENV SSH_KEY id_rsa
+RUN mkdir -p /root/.ssh && \
+    echo "StrictHostKeyChecking no" > /root/.ssh/config
+
 RUN { \
     echo "#!/bin/bash"; \
     echo "eval \$(ssh-agent) >/dev/null"; \
-    echo "ssh-add /root/.ssh/\$SSH_KEY"; \
+    echo "ssh-add /root/.ssh/ssh_key"; \
     echo "exec \"\$@\""; \
     } > /entrypoint.sh && chmod 755 /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/test/README.md
+++ b/test/README.md
@@ -27,6 +27,15 @@ For `--base <base>`, the default names are `<base>@example.com`, `<base>_ws` and
 
 For `--vcs-provider <vcs>`, supported providers include Gitlab (gitlab), GitHub Enterprise (GHE) and Bitbucker Server (bbs).
 
+**Troubleshooting**
+
+If you get an error from Ruby/Bundler like:
+
+    Could not find tzinfo-1.2.6 in any of the sources
+    Run `bundle install` to install missing gems.
+
+You need to remove the `Gemfile.lock` from the root of the repository.
+
 **Caveats & implementation notes**
 
 This script will create local `inventory.yaml` and `params.json` files, and remove any existing ones. The `../inventory.yaml` file is left for further bolt runs; the `params.json` file contains sensitive information and is removed upon a successful run.

--- a/test/configTestVm.sh
+++ b/test/configTestVm.sh
@@ -8,8 +8,7 @@ docker pull $test_image
 
 docker run -ti --rm \
        --volume "$PWD"/..:/app \
-       --volume "$HOME"/.ssh:/root/.ssh \
-       --env SSH_KEY="$ssh_key" \
+       --volume "$HOME"/.ssh/$ssh_key:/root/.ssh/ssh_key \
        --env CD4PE_IMAGE="$CD4PE_IMAGE" \
        --env CD4PE_VERSION="$CD4PE_VERSION" \
        $test_image \


### PR DESCRIPTION
Previously we were mounting in and using the entire ~/.ssh/ directory,
which can lead to problems depending on what you have in there when
you run the script.

We only need the SSH key though, so instead just mount in that
individual file instead of the entire directory.

Also add a note to the README about Gemfile.lock causing problems and
how to fix it.