### PR TITLE
(CDPE-3231) Add OS family check for cd4pe installation

### DIFF
--- a/lib/puppet/functions/cd4pe/compiling_server_osfamily.rb
+++ b/lib/puppet/functions/cd4pe/compiling_server_osfamily.rb
@@ -1,0 +1,5 @@
+Puppet::Functions.create_function(:'cd4pe::compiling_server_osfamily') do
+  def compiling_server_osfamily
+    Facter.value('osfamily')
+  end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,6 +25,12 @@ class cd4pe (
   if ( $facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] == '8' ){
     fail('You cannot use the cd4pe module to install on EL 8')
   }
+
+  $compiling_server_osfamily = cd4pe::compiling_server_osfamily()
+  if ( $compiling_server_osfamily != $facts['os']['family']){
+    fail("The PE Master OS '${compiling_server_osfamily}' must match the cd4pe agent node OS '${facts['os']['family']}'")
+  }
+
   # Restrict to linux only?
   include docker
   include cd4pe::anchors


### PR DESCRIPTION
Prior to this commit, it was possible to attempt an installation of
cd4pe on an agent with a different OS release than the PE master.  This
installation attempt would fail, generally looking for postgresql
packages with an error that would likely not lead a user to suspect the
actual cause of the problem.

With this commit, we will now compare the OS family to make sure they
are the same before continuing.

Tested by running with RHEL agent against a RHEL master, and the run
completed successfully.  With an Ubuntu agent against the same RHEL
master, you get an immediate failure:

```
Info: Using configured environment 'production'
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Retrieving locales
Info: Loading facts
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Function Call, The PE Master OS 'RedHat' must match the cd4pe agent node OS 'Debian' (file: /etc/puppetlabs/code/environments/production/modules/cd4pe/manifests/init.pp, line: 31, column: 5) on node osmotic-genie.delivery.puppetlabs.net
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
```