### PR TITLE
Revert "(CDPE-3231) Add OS family check for cd4pe installation"

### DIFF
--- a/lib/puppet/functions/cd4pe/compiling_server_osfamily.rb
+++ b/lib/puppet/functions/cd4pe/compiling_server_osfamily.rb
@@ -1,5 +1,0 @@
-Puppet::Functions.create_function(:'cd4pe::compiling_server_osfamily') do
-  def compiling_server_osfamily
-    Facter.value('osfamily')
-  end
-end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,12 +25,6 @@ class cd4pe (
   if ( $facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] == '8' ){
     fail('You cannot use the cd4pe module to install on EL 8')
   }
-
-  $compiling_server_osfamily = cd4pe::compiling_server_osfamily()
-  if ( $compiling_server_osfamily != $facts['os']['family']){
-    fail("The PE Master OS '${compiling_server_osfamily}' must match the cd4pe agent node OS '${facts['os']['family']}'")
-  }
-
   # Restrict to linux only?
   include docker
   include cd4pe::anchors


### PR DESCRIPTION
Reverts puppetlabs/puppetlabs-cd4pe#83

Reverting for now as it's breaking CI, and i'm extra concerned by your comment on the PR that i didn't see before merging

> I was able to successfully install CD4PE on an Ubuntu 16.04 agent from an 18.04 master.

This should not be possible, and 100% is not something we should continue to support.