### PR TITLE
(CDPE-3231) Add OS family check for cd4pe installation with test update

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -258,6 +258,9 @@ namespace :test do
           targets = nil
         end
 
+        # Facter override for osfamily, since we are testing against a Centos agent
+        ENV['FACTER_osfamily'] = 'RedHat'
+        ENV['FACTER_operatingsystemmajrelease'] = '7'
         if targets.nil? or targets.empty?
           Rake::Task['litmus:provision'].invoke('vmpooler', 'centos-7-x86_64')
           inventory_hash = inventory_hash_from_inventory_file

--- a/lib/puppet/functions/cd4pe/compiling_server_operatingsystemmajrelease.rb
+++ b/lib/puppet/functions/cd4pe/compiling_server_operatingsystemmajrelease.rb
@@ -1,0 +1,5 @@
+Puppet::Functions.create_function(:'cd4pe::compiling_server_operatingsystemmajrelease') do
+  def compiling_server_operatingsystemmajrelease
+    Facter.value('operatingsystemmajrelease')
+  end
+end

--- a/lib/puppet/functions/cd4pe/compiling_server_osfamily.rb
+++ b/lib/puppet/functions/cd4pe/compiling_server_osfamily.rb
@@ -1,0 +1,5 @@
+Puppet::Functions.create_function(:'cd4pe::compiling_server_osfamily') do
+  def compiling_server_osfamily
+    Facter.value('osfamily')
+  end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,6 +25,14 @@ class cd4pe (
   if ( $facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] == '8' ){
     fail('You cannot use the cd4pe module to install on EL 8')
   }
+
+  $compiling_server_osfamily = cd4pe::compiling_server_osfamily()
+  $compiling_server_operatingsystemmajrelease = cd4pe::compiling_server_operatingsystemmajrelease()
+  if ( $compiling_server_osfamily != $facts['os']['family'] or
+      $compiling_server_operatingsystemmajrelease != $facts['os']['release']['major']){
+    fail("The PE Master OS '${compiling_server_osfamily} ${compiling_server_operatingsystemmajrelease}' must match the cd4pe agent node OS '${facts['os']['family']} ${facts['os']['release']['major']}'")
+  }
+
   # Restrict to linux only?
   include docker
   include cd4pe::anchors


### PR DESCRIPTION
Prior to this commit, it was possible to attempt an installation of
cd4pe on an agent with a different OS release than the PE master.  This
installation attempt would fail, generally looking for postgresql
packages with an error that would likely not lead a user to suspect the
actual cause of the problem.

With this commit, we will now compare the OS family and major release 
to make sure they are the same before continuing.

I also update the Rakefile to do a facter override of the facts during testing.
Without this change, the test would think the PE Master was "Darwin", since it was
running on my mac desktop, and fail.  Overriding the fact to RedHat solves this, since
we also hardcode the agent as a centos-7 box.

Tests:
`CD4PE_IMAGE=artifactory.delivery.puppetlabs.net/cd4pe-dev CD4PE_VERSION=3.6.0-356-g173bb420b bundle exec rake test:install:cd4pe:module` now runs clean.  

Also tested by running with RHEL agent against a RHEL master, and the run
completed successfully. With an Ubuntu agent against the same RHEL
master, you get an immediate failure:

```
Info: Using configured environment 'production'
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Retrieving locales
Info: Loading facts
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Function Call, The PE Master OS 'RedHat 7' must match the cd4pe agent node OS 'Debian 18.04' (file: /etc/puppetlabs/code/environments/production/modules/cd4pe/manifests/init.pp, line: 33, column: 5) on node votive-vessel.delivery.puppetlabs.net
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
```