### PR TITLE
CDPE-2928 Bump metadata to 2.0.0 and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 No unreleased changes.
+
+## [2.0.0](https://github.com/puppetlabs/puppetlabs-cd4pe/tree/2.0.0)
+### Changed
+- default value of `$cd4pe_version` param in init.pp from 'latest'(2.x) to '3.x'
+### Removed
+- puppetlabs-pipelines module dependency
+### Added
+- OS family checking during installation
+### Fixed
+- syntax error in postgres.pp

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-cd4pe",
-  "version": "1.4.1",
+  "version": "2.0.0",
   "author": "Puppet Labs",
   "summary": "Module for CD4PE 2.x and 3.x",
   "license": "Apache-2.0",


### PR DESCRIPTION
This change bumps the metadata version to 2.0.0 and adds a short list of changes made in this new version to the CHANGELOG. I wasn't going to sort through the entire commit diff but I think I caught the important stuff.c