### PR TITLE
(maint) Use forge for fixtures

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,32 +1,25 @@
 fixtures:
+  forge_modules:
+    yumrepo_core: "puppetlabs-yumrepo_core"
+    augeas_core: "puppetlabs-augeas_core"
+    stdlib: "puppetlabs-stdlib"
+    docker: "puppetlabs-docker"
+    cron_core: "puppetlabs-cron_core"
+    translate: "puppetlabs-translate"
+    puppet_authorization: "puppetlabs-puppet_authorization"
+    service: "puppetlabs-service"
+    facts: "puppetlabs-facts"
+    puppet_agent: "puppetlabs-puppet_agent"
+    hocon: "puppetlabs-hocon"
+    ruby_task_helper: "puppetlabs-ruby_task_helper"
   repositories:
     puppet-enterprise-modules:
       repo: 'git@github.com:puppetlabs/puppet-enterprise-modules.git'
       ref: 'origin/kearney'
       target: 'spec/fixtures'
-    yumrepo_core:
-      repo: "git@github.com:puppetlabs/puppetlabs-yumrepo_core.git"
-      ref: origin/master
-    augeas_core:
-      repo: "git@github.com:puppetlabs/puppetlabs-augeas_core.git"
-      ref: origin/master
-    stdlib:
-        repo: "git@github.com:puppetlabs/puppetlabs-stdlib.git"
-        ref: origin/master
     pe_r10k:
         repo: "git@github.com:puppetlabs/puppetlabs-pe_r10k.git"
         ref: origin/2016.2.x
-    docker:
-        repo: "git@github.com:puppetlabs/puppetlabs-docker.git"
-        ref: origin/master
-    cron_core:
-        repo: "git@github.com:puppetlabs/puppetlabs-cron_core.git"
-        ref: origin/master
-    translate:
-        repo: "git@github.com:puppetlabs/puppetlabs-translate.git"
-    puppet_authorization:
-        repo: "git@github.com:puppetlabs/puppetlabs-puppet_authorization.git"
-        ref: origin/master
     enterprise_tasks:
         repo: "git@github.com:puppetlabs/enterprise_tasks.git"
         ref: origin/master
@@ -36,21 +29,7 @@ fixtures:
     provision:
         repo: "git@github.com:puppetlabs/provision.git"
         ref: origin/master
-    ruby_task_helper:
-        repo: "git@github.com:puppetlabs/puppetlabs-ruby_task_helper.git"
-        ref: origin/master
-    service:
-        repo: "git@github.com:puppetlabs/puppetlabs-service.git"
-        ref: origin/master
-    facts:
-        repo: "git@github.com:puppetlabs/puppetlabs-facts.git"
-        ref: origin/master
-    puppet_agent:
-        repo: "git@github.com:puppetlabs/puppetlabs-puppet_agent.git"
-        ref: origin/master
-    hocon:
-        repo: "git@github.com:puppetlabs/puppetlabs-hocon.git"
-        ref: origin/master
+
   symlinks:
      puppet_enterprise: "#{source_dir}/spec/fixtures/puppet-enterprise-modules/modules/puppet_enterprise"
      pe_concat: "#{source_dir}/spec/fixtures/puppet-enterprise-modules/modules/pe_concat"


### PR DESCRIPTION
Previous to this commit, the fixtures file was pulling #master for all
the modules we use. This could lead to tests failing if #master of a
module repo is broken.
This commit changes it to use forge for all modules that are published
to the forge. There are still a handful of PE specific ones / helpers
that are internal only and not published to the forge. Those are left to
 #master for now.