### PR TITLE
(CDPE-3310) Fix discover_pe_credentials task workspace parameter

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @puppetlabs/cd4pe

--- a/tasks/create_pipeline.rb
+++ b/tasks/create_pipeline.rb
@@ -13,6 +13,7 @@ password                 = params['password']
 repo_branch              = params['repo_branch']
 repo_name                = params['repo_name']
 pipeline_type            = params['pipeline_type']
+workspace                = params['workspace']
 
 require_relative File.join(params['_installdir'], 'cd4pe', 'lib', 'puppet_x', 'puppetlabs', 'cd4pe_client')
 

--- a/tasks/discover_pe_credentials.rb
+++ b/tasks/discover_pe_credentials.rb
@@ -15,6 +15,7 @@ pe_username              = params['pe_username']
 pe_password              = params['pe_password']
 pe_token                 = params['pe_token']
 pe_console_host          = params['pe_console_host']
+workspace                = params['workspace']
 
 require_relative File.join(params['_installdir'], 'cd4pe', 'lib', 'puppet_x', 'puppetlabs', 'cd4pe_client')
 
@@ -27,7 +28,7 @@ exitcode = 0
 result = {}
 begin
   client = PuppetX::Puppetlabs::CD4PEClient.new(web_ui_endpoint, username, password)
-  res = client.discover_pe_credentials(creds_name, pe_username, pe_password, pe_token, pe_console_host)
+  res = client.discover_pe_credentials(workspace, creds_name, pe_username, pe_password, pe_token, pe_console_host)
   if res.code != '200'
     raise "Error while discovering Puppet Enterprise credentials: #{res.body}"
   end


### PR DESCRIPTION
Prior to this commit, the discover_pe_credentials task definition
included a "workspace", but the task itself never used it.  Meanwhile
the discover_pe_credentials function in the CD4PE client code expected
it.  As a result, using the task always failed with an error regarding the
number of parameters.

With this commit, the task is updated to use the workspace parameter and
send it through to the client code.

I also added a CODEOWNERS fileto automate the reviewers for this repo.