### PR TITLE
(maint) Pin to facter 2.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ group :acceptance_tests do
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']
-facter_version = ENV['FACTER_GEM_VERSION']
+facter_version = ENV['FACTER_GEM_VERSION'] || '2.5.7'
 hiera_version = ENV['HIERA_GEM_VERSION']
 
 gems = {}


### PR DESCRIPTION
Previous to this commit, we were pulling in the latest facter gem.
However that was leading to failures in CI as it was causing catalog
compilation failures with 4.x, and no useful debug logging at the time
to figure out why.
For now, pin to 2.x to get CI working again while we investigate the
root cause to remove this pinning.