### PR TITLE
Add missing resolvable_hostname parameter to cd4pe::create_workspace

### DIFF
--- a/tasks/create_workspace.json
+++ b/tasks/create_workspace.json
@@ -17,6 +17,10 @@
     "workspace": {
       "type": "String[1]",
       "description": "Designates the workspace to be created."
+    },
+    "resolvable_hostname": {
+      "type": "Optional[String[1]]",
+      "description": "A resolvable internet address where the Continuous Delivery for PE server can be reached. Required only if the agent certificate is not the machine's resolvable internet address."
     }
   },
   "files": ["cd4pe/lib/"],


### PR DESCRIPTION
This parameter was missing from the metadata, making it impossible to set the parameter