### PR TITLE
Enable token lifetime param in discover_pe_credentials task

### DIFF
--- a/lib/puppet_x/puppetlabs/cd4pe_client.rb
+++ b/lib/puppet_x/puppetlabs/cd4pe_client.rb
@@ -182,7 +182,7 @@ module PuppetX::Puppetlabs
       make_request(:post, ROOT_AJAX_ENDPOINT, payload.to_json)
     end
 
-    def discover_pe_credentials(workspace, creds_name, pe_username, pe_password, pe_token, pe_console_host)
+    def discover_pe_credentials(workspace, creds_name, pe_username, pe_password, pe_token, pe_console_host, token_lifetime)
       payload = {
         op: 'DiscoverPuppetEnterpriseCredentials',
         content: {
@@ -191,6 +191,7 @@ module PuppetX::Puppetlabs
           username: pe_username,
           password: pe_password,
           token: pe_token,
+          lifetime: token_lifetime,
           puppetServerCertificate: '',
           puppetServerEndpoint: '',
           puppetServerPrivateKey: '',

--- a/tasks/discover_pe_credentials.json
+++ b/tasks/discover_pe_credentials.json
@@ -36,6 +36,10 @@
             "description": "The API token to use for the discovery process. Can be used in place of basic auth.",
             "sensitive": true
         },
+        "token_lifetime": {
+            "type": "Optional[String[1]]",
+            "description": "The amount of time the token generated for CD4PE should be valid. Defaults to 6 months."
+        },
         "resolvable_hostname": {
             "type": "Optional[String[1]]",
             "description": "A resolvable internet address where the Continuous Delivery for PE server can be reached. Required only if the agent certificate is not the machine's resolvable internet address."

--- a/tasks/discover_pe_credentials.rb
+++ b/tasks/discover_pe_credentials.rb
@@ -12,6 +12,7 @@ username                 = params['email']
 password                 = params['password']
 workspace                = params['workspace']
 creds_name               = params['creds_name']
+token_lifetime           = params['token_lifetime'] || '180d'
 pe_username              = params['pe_username']
 pe_password              = params['pe_password']
 pe_token                 = params['pe_token']
@@ -28,7 +29,7 @@ exitcode = 0
 result = {}
 begin
   client = PuppetX::Puppetlabs::CD4PEClient.new(web_ui_endpoint, username, password)
-  res = client.discover_pe_credentials(workspace, creds_name, pe_username, pe_password, pe_token, pe_console_host)
+  res = client.discover_pe_credentials(workspace, creds_name, pe_username, pe_password, pe_token, pe_console_host, token_lifetime)
   if res.code != '200'
     raise "Error while discovering Puppet Enterprise credentials: #{res.body}"
   end


### PR DESCRIPTION
This PR fixes a problem with the `cd4pe::discover_pe_credentials` task, as the original task would cause the PE token to only be valid for 1 hour. With this PR:
* The default value for a new token, if unspecified, is 180 days (`180d`)
* The discover_pe_credentials gets a new `token_lifetime` optional parameter that allows the user to specify a custom lifetime