### PR TITLE
Changes OS check to use name instead of family

### DIFF
--- a/lib/puppet/functions/cd4pe/compiling_server_osfamily.rb
+++ b/lib/puppet/functions/cd4pe/compiling_server_osfamily.rb
@@ -1,5 +1,0 @@
-Puppet::Functions.create_function(:'cd4pe::compiling_server_osfamily') do
-  def compiling_server_osfamily
-    Facter.value('osfamily')
-  end
-end

--- a/lib/puppet/functions/cd4pe/compiling_server_osname.rb
+++ b/lib/puppet/functions/cd4pe/compiling_server_osname.rb
@@ -1,0 +1,5 @@
+Puppet::Functions.create_function(:'cd4pe::compiling_server_osname') do
+  def compiling_server_osname
+    Facter.value('os')['name']
+  end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,11 +27,11 @@ class cd4pe (
     fail('You cannot use the cd4pe module to install on EL 8')
   }
 
-  $compiling_server_osfamily = cd4pe::compiling_server_osfamily()
+  $compiling_server_osname = cd4pe::compiling_server_osname()
   $compiling_server_operatingsystemmajrelease = cd4pe::compiling_server_operatingsystemmajrelease()
-  if ( $compiling_server_osfamily != $facts['os']['family'] or
+  if ( $compiling_server_osname != $facts['os']['name'] or
       $compiling_server_operatingsystemmajrelease != $facts['os']['release']['major']){
-    fail("The PE Master OS '${compiling_server_osfamily} ${compiling_server_operatingsystemmajrelease}' must match the cd4pe agent node OS '${facts['os']['family']} ${facts['os']['release']['major']}'")
+    fail("The PE Master OS '${compiling_server_osname} ${compiling_server_operatingsystemmajrelease}' must match the cd4pe agent node OS '${facts['os']['name']} ${facts['os']['release']['major']}'")
   }
 
   # Restrict to linux only?


### PR DESCRIPTION
I encountered this error message in our environment with Ubuntu:

```Error while evaluating a Function Call, The PE Master OS 'Debian 16.04' must match the cd4pe agent node OS 'Debian 18.04'```

I think OS family paints with too broad of a brush for some OSes and OS name gives a more accurate error:

```Error while evaluating a Function Call, The PE Master OS 'Ubuntu 16.04' must match the cd4pe agent node OS 'Ubuntu 18.04'```