### PR TITLE
(maint) Update the fixtures yaml to reflect the branch change on the pe_xl module

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -25,7 +25,7 @@ fixtures:
         ref: origin/master
     pe_xl:
         repo: "git@github.com:reidmv/reidmv-pe_xl.git"
-        ref: origin/master
+        ref: origin/main
     provision:
         repo: "git@github.com:puppetlabs/provision.git"
         ref: origin/master


### PR DESCRIPTION
- Update the ref to the pe_xl module so that it uses the proper branch
name as a consequence of moving away from using "master" terminology.
- Without this change we can't pull down the fixtures because the master
branch no longer exists on the pe_xl module.