### PR TITLE
(maint) Pin docker fixture to 3.10.2

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,7 +3,9 @@ fixtures:
     yumrepo_core: "puppetlabs-yumrepo_core"
     augeas_core: "puppetlabs-augeas_core"
     stdlib: "puppetlabs-stdlib"
-    docker: "puppetlabs-docker"
+    docker:
+        repo: "puppetlabs/docker"
+        ref: "3.10.2"
     cron_core: "puppetlabs-cron_core"
     translate: "puppetlabs-translate"
     puppet_authorization: "puppetlabs-puppet_authorization"


### PR DESCRIPTION
There is currently a bug with the 3.11.0 released version of docker
that is causing the network flags to be added improperly. I'm unsure if
this is due to our usages of it, or the PR number 647 on the docker
module.
The change was causing the docker create command to be passed two
network flags, one called bridge, and one called cd4pe.
This commit pins us to the last known good version will we investigate
and work with the IA content team to understand if it's our usage, or a
bad change.