### PR TITLE
(CDPE-3919) Add el 8 to supported OS list and 3.0.2 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 No unreleased changes.
 
+## [3.0.2](https://github.com/puppetlabs/puppetlabs-cd4pe/tree/3.0.2)
+- Updated the module's supported OS list to include el 8
+
 ## [3.0.1](https://github.com/puppetlabs/puppetlabs-cd4pe/tree/3.0.1)
 ### Changed
 - Updated the bolt tasks to properly account for https endpoints

--- a/metadata.json
+++ b/metadata.json
@@ -30,7 +30,8 @@
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-cd4pe",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "author": "Puppet Labs",
   "summary": "Module for CD4PE",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Since the Puppet platform now has support for RHEL/CentOS 8.1 and 8.2
we're updating the supported OS list of the module.
- Since we'll be performing a 3.0.2 release with the updated OS list I've included the commit for the release prep here.