### PR TITLE
Use new cert_allowlist_entry function name

### DIFF
--- a/manifests/db/postgres.pp
+++ b/manifests/db/postgres.pp
@@ -201,7 +201,7 @@ class cd4pe::db::postgres(
     value => "${postgres_cert_dir}/${certname}.private_key.pem",
   }
 
-  puppet_enterprise::pg::cert_whitelist_entry { 'cd4pe_whitelist':
+  puppet_enterprise::pg::cert_allowlist_entry { 'cd4pe_whitelist':
     user                          => $db_user,
     database                      => $db_name,
     allowed_client_certname       => $certname,


### PR DESCRIPTION
`puppet_enterprise::pg::cert_whitelist_entry` was renamed to `puppet_enterprise::pg::cert_allowlist_entry`. Using the old function name results in deprecation messages getting reported to our users. This change fixes that.