### PR TITLE
Add promote_pipeline_to_stage task and client method

### DIFF
--- a/lib/puppet_x/puppetlabs/cd4pe_client.rb
+++ b/lib/puppet_x/puppetlabs/cd4pe_client.rb
@@ -624,7 +624,7 @@ module PuppetX::Puppetlabs
         raise Puppet::Error "repo_type does not match one of: 'control', 'module'"
       end
     end
-    
+
     def make_request(type, api_url, payload = '')
       connection = Net::HTTP.new(@config[:server], @config[:port])
       headers = {

--- a/tasks/promote_repo_to_stage.json
+++ b/tasks/promote_repo_to_stage.json
@@ -1,0 +1,60 @@
+{
+  "description": "Promotes a pipeline to a specified Stage.",
+  "parameters": {
+    "email": {
+      "type": "String[1]",
+      "description": "The email address associated with the Continuous Delivery for PE login."
+    },
+    "password": {
+      "type": "String[1]",
+      "sensitive": true,
+      "description": "The password associated with the account."
+    },
+    "base64_cacert": {
+      "type": "Optional[String[1]]",
+      "description": "The CA cert of the CD4PE instance, base64 encoded"
+    },
+    "insecure_https": {
+      "type": "Optional[Boolean]",
+      "description": "Whether or not to make the https calls without verifying the CA cert. Only use this on test systems."
+    },
+    "workspace": {
+      "type": "String[1]",
+      "description": "Designates the workspace that the repo and pipeline are associated with"
+    },
+    "repo_name": {
+      "type": "String[1]",
+      "description": "The name of the repo."
+    },
+    "repo_type": {
+      "type": "Enum['module', 'control']",
+      "description": "The type of repository."
+    },
+    "branch_name": {
+      "type": "String[1]",
+      "description": "The name of the branch associated with the pipeline."
+    },
+    "stage_name": {
+      "type": "String[1]",
+      "description": "The name of the pipeline stage that the pipeline should be promoted to."
+    },
+    "commit_message": {
+      "type": "Optional[String[1]]",
+      "description": "The commit message to use for the promotion. If not specified, the original commit message of the promoted commit will be used."
+    },
+    "resolvable_hostname": {
+      "type": "Optional[String[1]]",
+      "description": "Optional. A resolvable internet address where the Continuous Delivery for PE server can be reached. Required only if the agent certificate is not the machine's resolvable internet address."
+    },
+    "web_ui_endpoint": {
+      "type": "Optional[String[1]]",
+      "description": "Optional. The endpoint where the web UI can be reached, in the form http://<resolvable_hostname>:<port>. Required if you set the web_ui_port parameter in the cd4pe class during installation."
+    }
+  },
+  "files": [
+    "cd4pe/lib/puppet_x/puppetlabs/cd4pe_client.rb",
+    "cd4pe/lib/puppet_x/puppetlabs/cd4pe_pipeline_utils.rb"
+  ],
+
+  "input_method": "stdin"
+}

--- a/tasks/promote_repo_to_stage.rb
+++ b/tasks/promote_repo_to_stage.rb
@@ -1,0 +1,46 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+
+require 'puppet'
+require 'uri'
+
+Puppet.initialize_settings
+$LOAD_PATH.unshift(Puppet[:plugindest])
+
+params = JSON.parse(STDIN.read)
+hostname                 = params['resolvable_hostname'] || Puppet[:certname]
+base64_cacert            = params['base64_cacert']
+insecure_https           = params['insecure_https'] || false
+username                 = params['email']
+password                 = params['password']
+workspace                = params['workspace']
+repo_name                = params['repo_name']
+repo_type                = params['repo_type']
+branch_name              = params['branch_name']
+stage_name               = params['stage_name']
+commit_message           = params['commit_message']
+
+require_relative File.join(params['_installdir'], 'cd4pe', 'lib', 'puppet_x', 'puppetlabs', 'cd4pe_client')
+require_relative File.join(params['_installdir'], 'cd4pe', 'lib', 'puppet_x', 'puppetlabs', 'cd4pe_pipeline_utils')
+
+uri = URI.parse(hostname)
+hostname = "http://#{hostname}" if uri.scheme.nil?
+
+web_ui_endpoint = params['web_ui_endpoint'] || "#{hostname}:8080"
+
+exitcode = 0
+result = {}
+
+begin
+  client = PuppetX::Puppetlabs::CD4PEClient.new(web_ui_endpoint, username, password, base64_cacert, insecure_https)
+  result = client.promote_pipeline_to_stage(workspace, repo_name, repo_type, branch_name, stage_name, commit_message)
+rescue => e
+  result[:_error] = {
+    msg: "Task failed: #{e.message}",
+    kind: 'puppetlabs-cd4pe/promote_pipeline_to_stage_error',
+    details: e.class.to_s,
+  }
+  exitcode = 1
+end
+
+puts result.to_json
+exit exitcode


### PR DESCRIPTION
The `promote_pipeline_to_stage` task can be used for - you guessed it - promoting a pipeline.
For that task to work, a method `promote_pipeline_to_stage` has been added to the client.

Note that no unit tests have been added yet because some of the current unit tests are failing - happy to add after some guidance on whether the existing unit tests should be fixed as well.