### PR TITLE
(CDPE-4193) Respect uri path when hitting cd4pe backend

### DIFF
--- a/lib/puppet_x/puppetlabs/cd4pe_client.rb
+++ b/lib/puppet_x/puppetlabs/cd4pe_client.rb
@@ -23,6 +23,7 @@ module PuppetX::Puppetlabs
         server: uri.host,
         port: uri.port,
         scheme: uri.scheme || 'https',
+        path: uri.path || '',
         base64_cacert: base64_cacert,
         insecure_https: insecure_https,
         email: email,
@@ -609,6 +610,7 @@ module PuppetX::Puppetlabs
     end
 
     def make_request(type, api_url, payload = '')
+      api_url = "#{@config[:path]}#{api_url}"
       connection = Net::HTTP.new(@config[:server], @config[:port])
       headers = {
         'Content-Type' => 'application/json',


### PR DESCRIPTION
Prior to this change, if the web_ui_endpoint supplied by CD4PE contained
a path after the port, we ignored it and simply attempted to hit the
server/port. This historically worked just fine, as CD4PE never
specified a path after the port; however, in CD4PE 4.5.0, we introduced
a path prefix that all traffic to CD4PE has to respect.

With this change, we add logic to respect the URI path if one exists,
allowing us to use the puppetlabs-cd4pe module with CD4PE 4.5.0+.