### PR TITLE
Rename task to promote_pipeline_to_stage; add sha parameter

### DIFF
--- a/lib/puppet_x/puppetlabs/cd4pe_client.rb
+++ b/lib/puppet_x/puppetlabs/cd4pe_client.rb
@@ -596,22 +596,21 @@ module PuppetX::Puppetlabs
       make_request(:get, endpoint)
     end
 
-    def promote_pipeline_to_stage(workspace, repo_name, repo_type, branch_name, stage_name, commit_message)
+    def promote_pipeline_to_stage(workspace, repo_name, repo_type, branch_name, stage_name, commit_sha, commit_message)
       pipeline = get_pipeline_for_branch(workspace, repo_name, repo_type, branch_name)
       stage_index = CD4PEPipelineUtils.get_stage_index_by_name(pipeline[:stages], stage_name)
       unless pipeline[:buildStage] && pipeline[:buildStage][:imageEvent] 
         raise Puppet::Error "It looks like pipeline has not run before. Please run the pipeline and try promoting again."
       end
       
-      commitMsg = commit_message ? commit_message : pipeline[:buildStage][:imageEvent][:commitMsg]
       payload = {
         op: 'PipelinePromote',
         content: {
           pipelineId: pipeline[:id],
           branch: branch_name,
-          sha: pipeline[:buildStage][:imageEvent][:commitId],
+          sha: commit_sha ? commit_sha : pipeline[:buildStage][:imageEvent][:commitId],
           stageNumber: stage_index + 1, # (stage_index starts with 0)
-          commitMsg: commitMsg,
+          commitMsg: commit_message ? commit_message : pipeline[:buildStage][:imageEvent][:commitMsg],
         }
       }
       if repo_type == 'control'

--- a/tasks/promote_pipeline_to_stage.json
+++ b/tasks/promote_pipeline_to_stage.json
@@ -38,6 +38,10 @@
       "type": "String[1]",
       "description": "The name of the pipeline stage that the pipeline should be promoted to."
     },
+    "commit_sha": {
+      "type": "Optional[String[1]]",
+      "description": "The commit to promote. If not specified, takes the commit from the latest pipeline run."
+    },
     "commit_message": {
       "type": "Optional[String[1]]",
       "description": "The commit message to use for the promotion. If not specified, the original commit message of the promoted commit will be used."

--- a/tasks/promote_pipeline_to_stage.rb
+++ b/tasks/promote_pipeline_to_stage.rb
@@ -18,6 +18,7 @@ repo_type                = params['repo_type']
 branch_name              = params['branch_name']
 stage_name               = params['stage_name']
 commit_message           = params['commit_message']
+commit_sha               = params['commit_sha']
 
 require_relative File.join(params['_installdir'], 'cd4pe', 'lib', 'puppet_x', 'puppetlabs', 'cd4pe_client')
 require_relative File.join(params['_installdir'], 'cd4pe', 'lib', 'puppet_x', 'puppetlabs', 'cd4pe_pipeline_utils')
@@ -32,7 +33,7 @@ result = {}
 
 begin
   client = PuppetX::Puppetlabs::CD4PEClient.new(web_ui_endpoint, username, password, base64_cacert, insecure_https)
-  result = client.promote_pipeline_to_stage(workspace, repo_name, repo_type, branch_name, stage_name, commit_message)
+  result = client.promote_pipeline_to_stage(workspace, repo_name, repo_type, branch_name, stage_name, commit_sha, commit_message).body
 rescue => e
   result[:_error] = {
     msg: "Task failed: #{e.message}",

--- a/tasks/promote_pipeline_to_stage.rb
+++ b/tasks/promote_pipeline_to_stage.rb
@@ -43,5 +43,5 @@ rescue => e
   exitcode = 1
 end
 
-puts result.to_json
+puts result
 exit exitcode


### PR DESCRIPTION
1. The task was erroneously named `promote_repo_to_stage`, fixed that by renaming to the intended name `promote_pipeline_to_stage`
2. Added the `commit_sha` parameter to enable important use cases which need to promote a specific commit
