### PR TITLE
(maint) Update endpoints to include cd4pe slug

### DIFF
--- a/lib/puppet_x/puppetlabs/cd4pe_client.rb
+++ b/lib/puppet_x/puppetlabs/cd4pe_client.rb
@@ -9,12 +9,12 @@ module PuppetX::Puppetlabs
   class CD4PEClient < Object
     attr_reader :config
 
-    LOGIN_ENDPOINT = '/login'.freeze
-    ROOT_AJAX_ENDPOINT = '/root/ajax'.freeze
-    ROOT_ENDPOINT_SETTINGS = '/root/endpoint-settings'.freeze
-    ROOT_STORAGE_SETTINGS = '/root/storage-settings'.freeze
-    SIGNUP_ENDPOINT = '/signup'.freeze
-    HW_CONFIG_ENDPOINT = '/root/hw-config'.freeze
+    LOGIN_ENDPOINT = '/cd4pe/login'.freeze
+    ROOT_AJAX_ENDPOINT = '/cd4pe/root/ajax'.freeze
+    ROOT_ENDPOINT_SETTINGS = '/cd4pe/root/endpoint-settings'.freeze
+    ROOT_STORAGE_SETTINGS = '/cd4pe/root/storage-settings'.freeze
+    SIGNUP_ENDPOINT = '/cd4pe/signup'.freeze
+    HW_CONFIG_ENDPOINT = '/cd4pe/root/hw-config'.freeze
 
     def initialize(hostname, email = nil, password = nil, base64_cacert = nil, insecure_https = false)
       uri = URI.parse(hostname)


### PR DESCRIPTION
Prior to this update, it was not possible to use the  bundled tasks against newer CD4PE v4 installations because the endpoint URLs have changed.

With this update, tasks will once again work.  I specifically tested the create_user task.