### PR TITLE
Properly handle non-SSL endpoints for CD4PE 3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-No unreleased changes.
+- Prevent enforcement of SSL on connections to non-SSL endpoints
 
 ## [3.2.1](https://github.com/puppetlabs/puppetlabs-cd4pe/tree/3.2.1)
 - Correct name of promote_repo_to_stage task and add commit_sha parameter

--- a/lib/puppet_x/puppetlabs/cd4pe_client.rb
+++ b/lib/puppet_x/puppetlabs/cd4pe_client.rb
@@ -643,9 +643,9 @@ module PuppetX::Puppetlabs
         'Cookie' => @cookie,
       }
 
-      connection.use_ssl = true
+      connection.use_ssl = true if @config[:scheme] == 'https'
 
-      if @config[:insecure_https]
+      if @config[:insecure_https] && @config[:scheme] == 'https'
         connection.verify_mode = OpenSSL::SSL::VERIFY_NONE
       else
         connection.verify_mode = OpenSSL::SSL::VERIFY_PEER


### PR DESCRIPTION
This PR fixes the following error when trying to use Tasks in v3.2.1 of the module against a CD4PE 3.x HTTP endpoint:
```
Error: Finished with exit code 1
{:_error=>{:msg=>"Task failed: SSL_connect returned=1 errno=0 state=error: wrong version number", :kind=>"puppetlabs-cd4pe/promote_pipeline_to_stage_error", :details=>"OpenSSL::SSL::SSLError"}}
```
It allows customers using both CD4PE 3.x and 4.x to leverage the a single version of the CD4PE module for executing Tasks against either instance.