### PR TITLE
3.2.3 release

### DIFF
--- a/.pdkignore
+++ b/.pdkignore
@@ -31,3 +31,4 @@
 /dev/
 .vendor
 project.clj
+RELEASE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 - No unreleased changes
+- 
+## [3.2.3](https://github.com/puppetlabs/puppetlabs-cd4pe/tree/3.2.3)
+### Fixed
+- Update default web_ui_endpoint handling in tasks to account for /cd4pe prefix in url.
 
 ## [3.2.2](https://github.com/puppetlabs/puppetlabs-cd4pe/tree/3.2.2)
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -7,21 +7,3 @@ Use version <=2.0.1 of this module to rapidly install and configure Continuous D
 For instructions, see https://puppet.com/docs/continuous-delivery/latest/install_module.html.
 
 Version 3.0.0 and later of this module is still used to configure Impact Analysis permissions on your PE master but no longer supports installation via Docker.
-
-## Release puppetlabs-cd4pe
-1. Create a branch off `main` using the following convention:
-```shell
-git checkout -b 3.1.0-release
-```
-2. On the new branch, update CHANGELOG.md with any changes in this release and metadata.json with the new version number.
-3. Commit these changes
-4. Tag the new branch with the new version number
-```shell
-git tag -a 3.1.0 -m "3.1.0"
-```
-5. Push your changes to origin for PR review and merge
-```shell
-git push origin 3.1.0-release --follow-tags
-```   
-6. Run `pdk build` in the root of the module to get the new tarball
-7. Log into https://forge.puppet.com as 'puppetlabs' and publish the new module version (credentials in CD4PE 1Password vault)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,17 @@
+## Release puppetlabs-cd4pe
+1. Create a branch off `main` using the following convention:
+```shell
+git checkout -b 3.1.0-release
+```
+2. On the new branch, update CHANGELOG.md with any changes in this release and metadata.json with the new version number.
+3. Commit these changes
+4. Tag the new branch with the new version number
+```shell
+git tag -a 3.1.0 -m "3.1.0"
+```
+5. Push your changes to origin for PR review and merge
+```shell
+git push origin 3.1.0-release --follow-tags
+```   
+6. Run `pdk build` in the root of the module to get the new tarball
+7. Log into https://forge.puppet.com as 'puppetlabs' and publish the new module version (credentials in CD4PE 1Password vault)

--- a/tasks/add_deployment_to_stage.rb
+++ b/tasks/add_deployment_to_stage.rb
@@ -28,7 +28,7 @@ require_relative File.join(params['_installdir'], 'cd4pe', 'lib', 'puppet_x', 'p
 uri = URI.parse(hostname)
 hostname = "http://#{hostname}" if uri.scheme.nil?
 
-web_ui_endpoint = params['web_ui_endpoint'] || "#{hostname}:8080"
+web_ui_endpoint = params['web_ui_endpoint'] || "#{hostname}:8080/cd4pe"
 
 exitcode = 0
 result = {}

--- a/tasks/add_job_to_stage.rb
+++ b/tasks/add_job_to_stage.rb
@@ -27,7 +27,7 @@ require_relative File.join(params['_installdir'], 'cd4pe', 'lib', 'puppet_x', 'p
 uri = URI.parse(hostname)
 hostname = "http://#{hostname}" if uri.scheme.nil?
 
-web_ui_endpoint = params['web_ui_endpoint'] || "#{hostname}:8080"
+web_ui_endpoint = params['web_ui_endpoint'] || "#{hostname}:8080/cd4pe"
 
 exitcode = 0
 result = {}

--- a/tasks/add_oauth_integration.rb
+++ b/tasks/add_oauth_integration.rb
@@ -21,7 +21,7 @@ require_relative File.join(params['_installdir'], 'cd4pe', 'lib', 'puppet_x', 'p
 uri = URI.parse(hostname)
 hostname = "http://#{hostname}" if uri.scheme.nil?
 
-web_ui_endpoint = params['web_ui_endpoint'] || "#{hostname}:8080"
+web_ui_endpoint = params['web_ui_endpoint'] || "#{hostname}:8080/cd4pe"
 
 exitcode = 0
 begin

--- a/tasks/add_pr_gate_to_stage.rb
+++ b/tasks/add_pr_gate_to_stage.rb
@@ -23,7 +23,7 @@ require_relative File.join(params['_installdir'], 'cd4pe', 'lib', 'puppet_x', 'p
 uri = URI.parse(hostname)
 hostname = "http://#{hostname}" if uri.scheme.nil?
 
-web_ui_endpoint = params['web_ui_endpoint'] || "#{hostname}:8080"
+web_ui_endpoint = params['web_ui_endpoint'] || "#{hostname}:8080/cd4pe"
 
 exitcode = 0
 result = {}

--- a/tasks/add_repo.rb
+++ b/tasks/add_repo.rb
@@ -27,7 +27,7 @@ require_relative File.join(params['_installdir'], 'cd4pe', 'lib', 'puppet_x', 'p
 uri = URI.parse(hostname)
 hostname = "http://#{hostname}" if uri.scheme.nil?
 logger = CD4PETaskLogger.new
-web_ui_endpoint = params['web_ui_endpoint'] || "#{hostname}:8080"
+web_ui_endpoint = params['web_ui_endpoint'] || "#{hostname}:8080/cd4pe"
 repo_name ||= source_repo_name
 exitcode = 0
 result = {}

--- a/tasks/add_vcs_integration.rb
+++ b/tasks/add_vcs_integration.rb
@@ -21,7 +21,7 @@ require_relative File.join(params['_installdir'], 'cd4pe', 'lib', 'puppet_x', 'p
 uri = URI.parse(hostname)
 hostname = "http://#{hostname}" if uri.scheme.nil?
 
-web_ui_endpoint = params['web_ui_endpoint'] || "#{hostname}:8080"
+web_ui_endpoint = params['web_ui_endpoint'] || "#{hostname}:8080/cd4pe"
 
 exitcode = 0
 result = {}

--- a/tasks/create_pipeline.rb
+++ b/tasks/create_pipeline.rb
@@ -21,7 +21,7 @@ require_relative File.join(params['_installdir'], 'cd4pe', 'lib', 'puppet_x', 'p
 
 uri = URI.parse(hostname)
 hostname = "http://#{hostname}" if uri.scheme.nil?
-web_ui_endpoint = params['web_ui_endpoint'] || "#{hostname}:8080"
+web_ui_endpoint = params['web_ui_endpoint'] || "#{hostname}:8080/cd4pe"
 exitcode = 0
 result = {}
 begin

--- a/tasks/create_user.rb
+++ b/tasks/create_user.rb
@@ -22,7 +22,7 @@ require_relative File.join(params['_installdir'], 'cd4pe', 'lib', 'puppet_x', 'p
 uri = URI.parse(hostname)
 hostname = "http://#{hostname}" if uri.scheme.nil?
 
-web_ui_endpoint = params['web_ui_endpoint'] || "#{hostname}:8080"
+web_ui_endpoint = params['web_ui_endpoint'] || "#{hostname}:8080/cd4pe"
 exitcode = 0
 begin
   client = PuppetX::Puppetlabs::CD4PEClient.new(web_ui_endpoint, nil, nil, base64_cacert, insecure_https)

--- a/tasks/create_workspace.rb
+++ b/tasks/create_workspace.rb
@@ -20,7 +20,7 @@ require_relative File.join(params['_installdir'], 'cd4pe', 'lib', 'puppet_x', 'p
 uri = URI.parse(hostname)
 hostname = "http://#{hostname}" if uri.scheme.nil?
 
-web_ui_endpoint = params['web_ui_endpoint'] || "#{hostname}:8080"
+web_ui_endpoint = params['web_ui_endpoint'] || "#{hostname}:8080/cd4pe"
 
 exitcode = 0
 result = {}

--- a/tasks/discover_pe_credentials.rb
+++ b/tasks/discover_pe_credentials.rb
@@ -25,7 +25,7 @@ require_relative File.join(params['_installdir'], 'cd4pe', 'lib', 'puppet_x', 'p
 uri = URI.parse(hostname)
 hostname = "http://#{hostname}" if uri.scheme.nil?
 
-web_ui_endpoint = params['web_ui_endpoint'] || "#{hostname}:8080"
+web_ui_endpoint = params['web_ui_endpoint'] || "#{hostname}:8080/cd4pe"
 
 exitcode = 0
 result = {}

--- a/tasks/promote_pipeline_to_stage.rb
+++ b/tasks/promote_pipeline_to_stage.rb
@@ -26,7 +26,7 @@ require_relative File.join(params['_installdir'], 'cd4pe', 'lib', 'puppet_x', 'p
 uri = URI.parse(hostname)
 hostname = "http://#{hostname}" if uri.scheme.nil?
 
-web_ui_endpoint = params['web_ui_endpoint'] || "#{hostname}:8080"
+web_ui_endpoint = params['web_ui_endpoint'] || "#{hostname}:8080/cd4pe"
 
 exitcode = 0
 result = {}


### PR DESCRIPTION
This PR contains two commits. 

The first updates the default for the web_ui_endpoint to add /cd4pe onto the end of the path, as required by teams ui. This only changes the default behavior if the user does not supply the param themself, so as not to break users who have already updated it accordingly on their own.

The second removes the release instructions from the readme and moves them into a separate markdown file so that they won't be publicly exposed on the forge.