### PR TITLE
[CDPE-4886] accept empty pipelines branch

### DIFF
--- a/tasks/add_repo.rb
+++ b/tasks/add_repo.rb
@@ -41,7 +41,7 @@ begin
   created_repo = JSON.parse(repo_res.body, symbolize_names: true)
   result[:repository] = created_repo
   # Create the base pipeline & webhook to mimic the front-end workflow if a PaC branch isn't specified
-  if pipelines_as_code_branch.empty?
+  if pipelines_as_code_branch == nil
     pipeline_res = client.create_pipeline(workspace, repo_name, source_repo_branch, repo_type)
     if pipeline_res.code != '200'
       raise "Error while adding pipeline:\n #{pipeline_res.body}"


### PR DESCRIPTION
When the optional parameter `pipelines_as_code_branch` is not supplied,
the type of `pipelines_as_code_branch` is `nil`, which has no `.empty?`.
Instead, just test whether it's a `nil`.