### PR TITLE
(maint) update release instructions for new publish action and fix v3.2.3 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 - No unreleased changes
 
-## [3.2.3](https://github.com/puppetlabs/puppetlabs-cd4pe/tree/3.2.3)
+## [v3.2.3](https://github.com/puppetlabs/puppetlabs-cd4pe/tree/v3.2.3)
 ### Fixed
 - Update default web_ui_endpoint handling in tasks to account for /cd4pe prefix in url.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,5 +13,4 @@ git tag -a 3.1.0 -m "3.1.0"
 ```shell
 git push origin 3.1.0-release --follow-tags
 ```   
-6. Run `pdk build` in the root of the module to get the new tarball
-7. Log into https://forge.puppet.com as 'puppetlabs' and publish the new module version (credentials in CD4PE 1Password vault)
+6. Run the "Publish module" GitHub Action to publish the new version to the forge.


### PR DESCRIPTION
This PR updates RELEASE.md to use the new publish module github action for pushing changes to the forge, rather than directing devs to build locally and manually push to the forge by logging in with the shared credentials.

It also has a second commit to fix an error in the changelog for version 3.2.3, where the changelog didn't reflect the new version format (vX.Y.Z rather than X.Y.Z), causing a dead link.