### PR TITLE
(CDPE-4883) clarify generic login error response

### DIFF
--- a/lib/puppet_x/puppetlabs/cd4pe_client.rb
+++ b/lib/puppet_x/puppetlabs/cd4pe_client.rb
@@ -70,7 +70,7 @@ module PuppetX::Puppetlabs
           raise Puppet::Error, "Invalid login credentials to CD4PE host: #{@config[:server]}"
         end
       else
-        raise Puppet::Error, "Invalid login credentials to CD4PE host: #{@config[:server]}"
+        raise Puppet::Error, "Received failed response logging in to CD4PE host at #{@config[:server]}: #{response.code} #{response.body}"
       end
     end
 


### PR DESCRIPTION
Previously the generic error handler that'd catch all non-401 error states when the client was setting the auth cookie would swallow the error response and instead return an error about invalid login credentials. However this was misleading as invalid credentials would result in a 401, and the handler was catching all error responses except 401s. This adjusts it to instead return the error status and body.