### PR TITLE
(CDPE-6453) Update module versions for Puppet 8 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,15 +10,15 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.19.0 < 7.0.0"
+      "version_requirement": ">= 4.19.0 < 10.0.0"
     },
     {
       "name": "puppetlabs-puppet_authorization",
-      "version_requirement": ">= 0.5.0 < 1.0.0"
+      "version_requirement": ">= 0.5.0 < 2.0.0"
     },
     {
       "name":"puppetlabs-docker",
-      "version_requirement": ">= 3.0.0 < 4.0.0"
+      "version_requirement": ">= 3.0.0 < 10.0.0"
     },
     {
       "name":"puppetlabs-hocon",
@@ -51,7 +51,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.10.0 < 7.0.0"
+      "version_requirement": ">= 4.10.0 < 9.0.0"
     }
   ],
   "pdk-version": "1.8.0",


### PR DESCRIPTION
The following updates increment the module versions to support Puppet 8. Running this set on a CD4PE 5.3.2 install against a 2021.7.0 PE ran without problems. Tested job runs on job hardware provisioned using the docker module and deployments. Running `puppet module list` on the PE server afterwards showed no module incompatibilities. 
For testing, I used a Puppetfile of:

```
mod 'cd4pe',
  :git => 'https://github.com/puppetlabs/puppetlabs-cd4pe.git',
  :branch => 'cdpe-6453/update-versions-for-puppet8'

mod 'puppetlabs-cd4pe_jobs', '1.6.3'
mod 'puppetlabs-concat', '9.0.2'
mod 'puppetlabs-hocon', '1.1.0'
mod 'puppetlabs-puppet_authorization', '1.0.0'
mod 'puppetlabs-stdlib', '9.6.0'
mod 'puppetlabs-docker', '9.1.0'
mod 'puppetlabs-apt', '9.4.0'
mod 'puppetlabs-translate', '1.1.0'
mod 'puppetlabs-powershell', '6.0.0'
```